### PR TITLE
[Bugfix][MiniMax-M3] Backport token-major top-k handling

### DIFF
--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -424,6 +424,9 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
         # (decode at [:, :nd], prefill at [:, nd:]) and return views into it; the
         # kernels' out= writes out[:, :total_q]. None -> allocate fresh.
         buf = self.topk_indices_buffer
+        buf_htk = (
+            buf if buf is None or current_platform.is_rocm() else buf.transpose(0, 1)
+        )
         decode_topk: torch.Tensor | None = None
         prefill_topk: torch.Tensor | None = None
         if index_md.num_decodes > 0:
@@ -441,7 +444,7 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
                 self.num_kv_heads,
                 d.decode_query_len,
                 d.max_decode_query_len,
-                out=buf,
+                out=buf_htk,
             )
         if index_md.num_prefills > 0:
             p = index_md.prefill
@@ -465,7 +468,7 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
                 self.topk_blocks,
                 self.init_blocks,
                 self.local_blocks,
-                out=buf[:, nd:, :] if buf is not None else None,
+                out=buf_htk[:, nd:, :] if buf_htk is not None else None,
             )
         return decode_topk, prefill_topk
 

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -384,7 +384,14 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
         nd = main_md.num_decode_tokens
         num_tokens = main_md.num_actual_tokens
         # Indexer top-k from the shared buffer: decode [:, :nd], prefill [:, nd:].
-        topk = layer.topk_indices_buffer  # type: ignore[attr-defined]
+        topk_buffer = layer.topk_indices_buffer  # type: ignore[attr-defined]
+        assert topk_buffer is not None
+
+        topk = (
+            topk_buffer
+            if current_platform.is_rocm()
+            else topk_buffer[:num_tokens].transpose(0, 1)
+        )
         assert topk is not None
         hd = self.head_size
         q = query[:num_tokens].view(-1, self.num_heads, hd)


### PR DESCRIPTION
## What

Backport vLLM's merged MiniMax M3 Triton top-k buffer correction from
vllm-project/vllm#49149 (`d1a8ba63d9d2bb51ebf60dd5ea1463cf61c70cea`).

The NVIDIA model owns a token-major persistent buffer (`[T, H, K]`), while the
Triton indexer and sparse-attention kernels consume head-major views
(`[H, T, K]`). This patch transposes the buffer at those kernel boundaries.
The ROCm path is unchanged.

## Why

Without the view conversion, head and token coordinates alias in the shared
buffer. The indexer can therefore select incorrect or non-causal blocks. In the
observed failure this produced an all-masked attention row, propagated NaNs
through the residual stream, and returned NUL bytes despite successful model
loading.

The transpose is a no-copy view, so this does not add a model-sized allocation.

## Validation

- `UV_CACHE_DIR=/tmp/lvllm-uv-cache uv run --no-project python -m py_compile vllm/models/minimax_m3/common/indexer.py vllm/models/minimax_m3/common/sparse_attention.py`
- `git diff --check`
- Model-level validation used LvLLM v2.3.8 with the equivalent NVIDIA
  token-major/head-major views applied, `olka-fi/MiniMax-M3-MXFP4`, one RTX PRO
  6000 (SM120), `TRITON_ATTN`, BF16 KV cache, and `--max-model-len 16384`:
  - cold 184-token prompt + 8 completion tokens: 5.07 s, coherent output
  - warm 184-token prompt + 28 completion tokens: 3.06 s, returned `Paris`
  - exact 16,000-token prompt + 1 completion token: 122.57 s, no corruption
  - 193-token prompt + 500 completion tokens: 21.09 s, 500 coherent tokens
  - fixed server log: zero non-finite reports; response payload: zero NUL bytes

## Duplicate check

No matching LvLLM issue or pull request was found for `MiniMax M3 top-k`,
`49149`, or the token-major buffer correction. This is intentionally a backport
of the already-reviewed upstream vLLM fix rather than a competing
implementation.

## AI assistance disclosure

This backport and PR description were prepared with OpenAI Codex assistance.
The PR is left in draft for human line-by-line review before it is marked ready.
