### PR TITLE
[Bugfix][MoE] Support CPU-resident compressed MXFP4 experts

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -960,3 +960,69 @@ def test_compressed_tensors_mxfp4(vllm_runner):
         llm.apply_model(check_model)
         output = llm.generate_greedy("Hello my name is", max_tokens=4)
         assert output
+
+
+def test_compressed_tensors_mxfp4_cpu_resident_experts(monkeypatch):
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
+        compressed_tensors_moe_w4a4_mxfp4 as mxfp4_moe,
+    )
+
+    class CpuRoutedExperts(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.is_gpu_resident_layer = False
+
+    monkeypatch.setattr(mxfp4_moe, "RoutedExperts", CpuRoutedExperts)
+    monkeypatch.setattr(mxfp4_moe.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+
+    method = object.__new__(mxfp4_moe.CompressedTensorsW4A4Mxfp4MoEMethod)
+    method.group_size = 32
+    layer = CpuRoutedExperts()
+    method.create_weights(
+        layer,
+        num_experts=2,
+        hidden_size=64,
+        intermediate_size_per_partition=64,
+        params_dtype=torch.bfloat16,
+    )
+
+    parameter_names = (
+        "w13_weight_packed",
+        "w2_weight_packed",
+        "w13_weight_scale",
+        "w2_weight_scale",
+    )
+    assert all(getattr(layer, name).device.type == "cpu" for name in parameter_names)
+
+    method.process_weights_after_loading(layer)
+    assert hasattr(layer, "w13_weight_packed")
+    assert hasattr(layer, "w2_weight_packed")
+    assert not hasattr(layer, "w13_weight")
+    assert not hasattr(layer, "w2_weight")
+
+
+@pytest.mark.parametrize("use_cutlass_mxfp4", [False, True])
+def test_compressed_tensors_mxfp4_forwards_swiglu_params(use_cutlass_mxfp4):
+    from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+        Mxfp4MoeBackend,
+    )
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_mxfp4 import (  # noqa: E501
+        CompressedTensorsW4A4Mxfp4MoEMethod,
+    )
+
+    method = object.__new__(CompressedTensorsW4A4Mxfp4MoEMethod)
+    method.use_cutlass_mxfp4 = use_cutlass_mxfp4
+    method.mxfp4_backend = Mxfp4MoeBackend.MARLIN
+    method.moe = Mock(swiglu_alpha=1.702, swiglu_beta=1.0, swiglu_limit=7.0)
+    layer = Mock(
+        w13_weight_scale=torch.ones(1),
+        w2_weight_scale=torch.ones(1),
+    )
+
+    config = method.get_fused_moe_quant_config(layer)
+
+    assert config is not None
+    assert config.gemm1_alpha == 1.702
+    assert config.gemm1_beta == 1.0
+    assert config.gemm1_clamp_limit == 7.0

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1692,8 +1692,16 @@ class RoutedExperts(PluggableLayer):
  
     
     def _process_mxfp4(self):
-        w13_weight = self.w13_weight
-        w2_weight = self.w2_weight 
+        w13_weight = (
+            self.w13_weight_packed
+            if hasattr(self, "w13_weight_packed")
+            else self.w13_weight
+        )
+        w2_weight = (
+            self.w2_weight_packed
+            if hasattr(self, "w2_weight_packed")
+            else self.w2_weight
+        )
         w13_weight_scale = self.w13_weight_scale
         w2_weight_scale = self.w2_weight_scale 
          

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -69,6 +69,12 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        device = (
+            torch.cuda.current_device() if current_platform.is_cuda_alike() else "cpu"
+        )
+        if isinstance(layer, RoutedExperts) and not layer.is_gpu_resident_layer:
+            device = "cpu"
+
         layer.num_experts = num_experts
         layer.params_dtype = params_dtype
 
@@ -80,6 +86,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
                 hidden_size // 2,
                 requires_grad=False,
                 dtype=torch.uint8,
+                device=device,
             ),
             requires_grad=False,
         )
@@ -93,6 +100,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
                 # 2 fp4 items are packed in the input dimension
                 intermediate_size_per_partition // 2,
                 dtype=torch.uint8,
+                device=device,
             ),
             requires_grad=False,
         )
@@ -106,6 +114,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
                 # 2 fp4 items are packed in the input dimension
                 hidden_size // self.group_size,
                 dtype=torch.uint8,
+                device=device,
             ),
             requires_grad=False,
         )
@@ -122,6 +131,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
                 # 2 fp4 items are packed in the input dimension
                 intermediate_size_per_partition // self.group_size,
                 dtype=torch.uint8,
+                device=device,
             ),
             requires_grad=False,
         )
@@ -133,20 +143,30 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
     ) -> FusedMoEQuantConfig | None:
         if self.use_cutlass_mxfp4:
             # W4A4: both weights and activations quantized to MXFP4
-            return mxfp4_moe_quant_config(
+            config = mxfp4_moe_quant_config(
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
             )
+            config.gemm1_alpha = self.moe.swiglu_alpha
+            config.gemm1_beta = self.moe.swiglu_beta
+            config.gemm1_clamp_limit = self.moe.swiglu_limit
+            return config
         else:
             # W4A16: weight-only via Marlin
             return make_mxfp4_moe_quant_config(
                 mxfp4_backend=self.mxfp4_backend,
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
+                gemm1_alpha=self.moe.swiglu_alpha,
+                gemm1_beta=self.moe.swiglu_beta,
+                swiglu_limit=self.moe.swiglu_limit,
                 layer=layer,
             )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        if not layer.is_gpu_resident_layer:
+            return
+
         layer.w13_weight = torch.nn.Parameter(
             layer.w13_weight_packed.data, requires_grad=False
         )


### PR DESCRIPTION
## What

Make the compressed-tensors MXFP4 MoE path honor LvLLM's hybrid
CPU/GPU-resident expert layout:

- allocate weights and scales on the resident layer's intended device;
- leave CPU-resident weights in their checkpoint-compatible packed form;
- let the LvLLM MXFP4 runtime consume either packed or converted weight names;
- forward MiniMax M3's SwiGLU-OAI alpha, beta, and clamp limit into both the
  Cutlass W4A4 and Marlin W4A16 quant configs.

## Why

The compressed MXFP4 implementation had not been adapted to the hybrid
residency behavior already present in LvLLM's NVFP4, FP8, WNA16, and native
MXFP4 paths. Under the CUDA default-device context it allocated every expert
layer on the GPU, including layers configured for CPU residency, causing an
immediate GPU out-of-memory failure. Its post-load conversion also deleted the
packed parameter names that the CPU-resident LvLLM runtime needs.

Separately, MiniMax M3 uses parameterized SwiGLU-OAI. Omitting its alpha, beta,
and clamp limit either triggers the mandatory clamp assertion or computes the
wrong activation.

GPU-resident behavior is unchanged apart from receiving the model's activation
parameters.

## Validation

- Focused regression tests:

  `PYTHONPATH=/tmp/lvllm-pr-pytest /opt/lvllm/.venv/bin/python -m pytest --confcutdir=tests/quantization tests/quantization/test_compressed_tensors.py -k "mxfp4_cpu_resident_experts or mxfp4_forwards_swiglu_params" -q`

  Result: `3 passed, 45 deselected`.

- Python compilation passed for both changed implementation files and the test
  file.
- `ruff check` and `ruff format --check` passed for the compressed-tensors
  implementation and test file.
- `git diff --check` passed.
- `routed_experts.py` has 68 pre-existing whole-file Ruff findings; this change
  adds no new style finding in the edited block.
- Combined model validation used this patch plus the separate MiniMax M3 top-k
  layout correction on LvLLM v2.3.8, `olka-fi/MiniMax-M3-MXFP4`, one RTX PRO
  6000 (SM120), `TRITON_ATTN`, BF16 KV cache, and `--max-model-len 16384`:
  the server loaded, a cold and warm smoke inference were coherent, an exact
  16,000-token prompt completed without corruption, and a 500-token decode
  returned 500 coherent tokens in 21.09 s.

## Duplicate check

No matching LvLLM issue or pull request was found for MXFP4 hybrid residency or
compressed-tensors MXFP4. vLLM's open MiniMax M3 NVFP4 correctness work does not
cover LvLLM's CPU-resident layer allocation or packed-weight lifecycle.

## AI assistance disclosure

The implementation, tests, and PR description were prepared with OpenAI Codex
assistance. The PR is left in draft for human line-by-line review before it is
marked ready.
